### PR TITLE
Ordering for logged in users

### DIFF
--- a/app/models/order_form.rb
+++ b/app/models/order_form.rb
@@ -7,7 +7,6 @@ class OrderForm
   attr_writer :cart
 
   def save
-    set_password_for_user
     if valid?
       persist
       true
@@ -24,7 +23,7 @@ class OrderForm
 
 
   private
-  
+
 
   def valid?
     user.valid? &&


### PR DESCRIPTION
Ordering with the logged in user does no longer:
- logs off the session: refactored the orders_controller to support ordering and paying on the same form.
- resets the password of the current_user to a token_password: there was a method doing this, no clue why :stuck_out_tongue_winking_eye: 

